### PR TITLE
Add treafik support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ git clone https://github.com/Pronovix/docker-drupal-dev.git drupal-dev
 $ mkdir build;
 $ ln -s drupal-dev/docker-compose.yml
 $ ln -s drupal-dev/Dockerfile
-$ printf "COMPOSE_PROJECT_NAME=[YOUR_PROJECT_NAME]\n#You can find examples for available customization in the drupal-dev/examples/.env file.\n" > .env && source .env
+$ printf "COMPOSE_PROJECT_BASE_URL=%s.test\nCOMPOSE_PROJECT_NAME=[YOUR_PROJECT_NAME]\n#You can find examples for available customization in the drupal-dev/examples/.env file.\n" > .env && source .env
 $ docker-compose up -d --build
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,6 @@
 
 version: "3.3"
 
-# TODO Add Traefik configuration.
-# If Traefik is not installed it does not do any harm, otherwise it provides a nice addition.
-
 services:
   database:
     # 10.2 is the default database because it has InnoDB 5.7, older versions are not supported by our modules.
@@ -19,12 +16,8 @@ services:
       MYSQL_DATABASE: ${DB_NAME:-drupal}
       MYSQL_USER: ${DB_USER:-drupal}
       MYSQL_PASSWORD: ${DB_PASSWORD:-password}
-      POSTGRES_PASSWORD: ${DB_PASSWORD:-password}
-      POSTGRES_DB: ${DB_NAME:-drupal}
-      POSTGRES_USER: ${DB_USER:-drupal}
     volumes:
       - database_data:/var/lib/mysql
-#      - database_data:/var/lib/postgresql/data
 
   php:
     # Building a project specific PHP image is beneficial for us, because PhpStorm's PHPCS integration only allows
@@ -104,8 +97,6 @@ services:
     depends_on:
       - php
     environment:
-      APACHE_BACKEND_HOST: php
-      APACHE_SERVER_ROOT: ${WEB_ROOT:-/mnt/files/local_mount/build/web}
       NGINX_STATIC_CONTENT_OPEN_FILE_CACHE: "off"
       NGINX_BACKEND_HOST: php
       NGINX_VHOST_PRESET: drupal8
@@ -113,6 +104,13 @@ services:
       NGINX_STATIC_404_TRY_INDEX: 1
     volumes:
       - .:/mnt/files/local_mount
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=web"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME:-my_project}_webserver.rule=Host(`${COMPOSE_PROJECT_BASE_URL}`)"
+    networks:
+      - default
+      - web
 
   chrome:
     image: drupalci/webdriver-chromedriver:production
@@ -134,6 +132,14 @@ services:
     container_name: "${COMPOSE_PROJECT_NAME:-my_project}_mailhog"
     ports:
       - 8025
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=web"
+      - "traefik.http.services.${COMPOSE_PROJECT_NAME:-my_project}_mailhog.loadbalancer.server.port=8025"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME:-my_project}_mailhog.rule=Host(`mailhog.${COMPOSE_PROJECT_BASE_URL}`)"
+    networks:
+      - default
+      - web
 
   node:
     image: ${NODE_IMAGE:-wodby/node:12}
@@ -143,7 +149,19 @@ services:
     working_dir: /mnt/files/local_mount
     volumes:
       - .:/mnt/files/local_mount
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=web"
+      - "traefik.http.services.${COMPOSE_PROJECT_NAME:-my_project}_node.loadbalancer.server.port=3000"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME:-my_project}_node.rule=Host(`node.${COMPOSE_PROJECT_BASE_URL}`)"
+    networks:
+      - default
+      - web
 
 volumes:
   # Persistent database storage.
   database_data:
+
+networks:
+  web:
+    external: true

--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -1,0 +1,7 @@
+version: "2"
+
+syncs:
+  docker-sync:
+    src: './'
+    sync_userid: '501'
+    sync_excludes: ['.gitignore', '.git/', '.idea/']

--- a/drupal/settings.php
+++ b/drupal/settings.php
@@ -17,7 +17,7 @@ $databases['default']['default'] = [
   'driver' => getenv('DB_DRIVER'),
 ];
 
-$settings['trusted_host_patterns'] = ['^webserver$', '^localhost$'];
+$settings['trusted_host_patterns'] = ['^webserver$', '^localhost$', '^.+\.test$'];
 $settings['file_private_path'] = '/mnt/files/private';
 
 // Ideal for development and testing.

--- a/traefik.yml
+++ b/traefik.yml
@@ -1,0 +1,21 @@
+version: '3'
+
+services:
+  traefik:
+    image: traefik:v2.0
+    command: --api.insecure=true --providers.docker
+    ports:
+      - '80:80'
+      - '443:443'
+      - '8080:8080'
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - web
+    labels:
+      - 'traefik.frontend.rule=Host:traefik.test'
+      - 'traefik.port=8080'
+
+networks:
+  web:
+    external: true


### PR DESCRIPTION
Enabled traefik support for webserver, mailhog and node services.
Updated README.md.
Added docker-sync.yml.
Added traefik.yml.
Add a new network "web" for docker-compose to use with traefik.